### PR TITLE
Fix multiple tags showing up with commas

### DIFF
--- a/app/resources/api/bookmark_resource.rb
+++ b/app/resources/api/bookmark_resource.rb
@@ -6,13 +6,21 @@ module Api
   class BookmarkResource < ApplicationResource
     model_name 'Link'
 
-    attributes *%i[title url comment source read moved_to_list_at public published_at tag_list]
+    attributes *%i[title url comment source read moved_to_list_at public published_at tag_string]
 
     relationship :tags, to: :many, class_name: 'Tag'
 
     filter :read
 
     before_save :populate_title
+
+    def tag_string
+      @model.tag_list.join(' ')
+    end
+
+    def tag_string=(value)
+      @model.tag_list = value.split(' ')
+    end
 
     def self.creatable_fields(context)
       super - %i[moved_to_list_at published_at]

--- a/frontend/app/models/bookmark.js
+++ b/frontend/app/models/bookmark.js
@@ -5,7 +5,7 @@ export default DS.Model.extend({
   url: DS.attr('string'),
   comment: DS.attr('string'),
   source: DS.attr('string'),
-  tagList: DS.attr('string'),
+  tag_string: DS.attr('string'),
   read: DS.attr('boolean'),
   moved_to_list_at: DS.attr('date'),
   public: DS.attr('boolean'),

--- a/frontend/app/templates/links/edit.hbs
+++ b/frontend/app/templates/links/edit.hbs
@@ -12,8 +12,8 @@
     {{input data-test-source id="source" autocapitalize="off" autocorrect="off" classNames="form-control" value=buffer.source}}
   </div>
   <div class='form-group'>
-    <label for="tagList">Tags</label>
-    {{input data-test-tags id="tagList" autocapitalize="off" autocorrect="off" classNames="form-control" value=buffer.tagList}}
+    <label for="tag_string">Tags</label>
+    {{input data-test-tags id="tag_string" autocapitalize="off" autocorrect="off" classNames="form-control" value=buffer.tag_string}}
   </div>
   <div class='form-group'>
     <label for="public">Public</label>

--- a/spec/requests/managing_links_spec.rb
+++ b/spec/requests/managing_links_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'managing links', type: :request do
           title: title,
           read: true,
           public: true,
-          'tag-list' => 'foo bar',
+          'tag-string' => 'foo bar',
         },
       },
     }


### PR DESCRIPTION
The issue was that tag_list is actually an array, and JSONAPI::Resources sends it that way, but Ember Data isn't prepared to work with arrays, so it automatically concatenates them with a comma.